### PR TITLE
In STM32, USB OTG CID >= 2.0 (0x00002000) GCCFG has changed.

### DIFF
--- a/include/unicore-mx/stm32/otg_common.h
+++ b/include/unicore-mx/stm32/otg_common.h
@@ -97,6 +97,10 @@
 #define OTG_GOTGCTL_HSHNPEN		(1 << 10)
 #define OTG_GOTGCTL_HNPRQ		(1 << 9)
 #define OTG_GOTGCTL_HNGSCS		(1 << 8)
+#define OTG_GOTGCTL_BVALOVAL	(1 << 7)
+#define OTG_GOTGCTL_BVALOEN		(1 << 6)
+#define OTG_GOTGCTL_AVALOVAL	(1 << 5)
+#define OTG_GOTGCTL_AVALOEN		(1 << 4)
 #define OTG_GOTGCTL_SRQ			(1 << 1)
 #define OTG_GOTGCTL_SRQSCS		(1 << 0)
 
@@ -219,7 +223,8 @@
 
 /* OTG general core configuration register (OTG_GCCFG) */
 /* Bits 31:22 - Reserved */
-#define OTG_GCCFG_NOVBUSSENS		(1 << 21)
+#define OTG_GCCFG_VBDEN			(1 << 21)
+#define OTG_GCCFG_NOVBUSSENS	(1 << 21)
 #define OTG_GCCFG_SOFOUTEN		(1 << 20)
 #define OTG_GCCFG_VBUSBSEN		(1 << 19)
 #define OTG_GCCFG_VBUSASEN		(1 << 18)

--- a/include/unicore-mx/usbd/backend/dwc_otg.h
+++ b/include/unicore-mx/usbd/backend/dwc_otg.h
@@ -42,7 +42,7 @@
 #define DWC_OTG_GRXFSIZ(base)		MMIO32((base) + 0x024)
 #define DWC_OTG_GNPTXFSIZ(base)		MMIO32((base) + 0x028)
 #define DWC_OTG_GNPTXSTS(base)		MMIO32((base) + 0x02C)
-#define DWC_OTG_GCCFG(base)			MMIO32((base) + 0x038)
+#define DWC_OTG_GGPIO(base)			MMIO32((base) + 0x038)
 #define DWC_OTG_CID(base)			MMIO32((base) + 0x03C)
 #define DWC_OTG_HPTXFSIZ(base)		MMIO32((base) + 0x100)
 #define DWC_OTG_DIEPxTXF(base, x)	MMIO32((base) + 0x104 + 4*((x)-1))
@@ -117,6 +117,10 @@
 #define DWC_OTG_GOTGCTL_HSHNPEN		(1 << 10)
 #define DWC_OTG_GOTGCTL_HNPRQ		(1 << 9)
 #define DWC_OTG_GOTGCTL_HNGSCS		(1 << 8)
+#define DWC_OTG_GOTGCTL_BVALOVAL	(1 << 7)
+#define DWC_OTG_GOTGCTL_BVALOEN		(1 << 6)
+#define DWC_OTG_GOTGCTL_AVALOVAL	(1 << 5)
+#define DWC_OTG_GOTGCTL_AVALOEN		(1 << 4)
 #define DWC_OTG_GOTGCTL_SRQ			(1 << 1)
 #define DWC_OTG_GOTGCTL_SRQSCS		(1 << 0)
 
@@ -229,16 +233,6 @@
 #define DWC_OTG_GRXSTSP_DPID_MDATA				(0x3 << 15)
 #define DWC_OTG_GRXSTSP_BCNT_MASK				(0x7ff << 4)
 #define DWC_OTG_GRXSTSP_EPNUM_MASK				(0xf << 0)
-
-/* OTG general core configuration register (DWC_OTG_GCCFG) */
-/* Bits 31:22 - Reserved */
-#define DWC_OTG_GCCFG_NOVBUSSENS		(1 << 21)
-#define DWC_OTG_GCCFG_SOFOUTEN			(1 << 20)
-#define DWC_OTG_GCCFG_VBUSBSEN			(1 << 19)
-#define DWC_OTG_GCCFG_VBUSASEN			(1 << 18)
-/* Bit 17 - Reserved */
-#define DWC_OTG_GCCFG_PWRDWN			(1 << 16)
-/* Bits 15:0 - Reserved */
 
 /* Device-mode CSRs */
 /* OTG device control register (DWC_OTG_DCTL) */

--- a/lib/usbd/backend/usbd_stm32_otg_fs.c
+++ b/lib/usbd/backend/usbd_stm32_otg_fs.c
@@ -70,6 +70,16 @@ static usbd_device * stm32_otg_fs_usbd_init(void)
 	private_data.ep_count = ENDPOINT_COUNTS;
 	_usbd_dev.backend_data = &private_data;
 
+	if (OTG_FS_CID >= 0x00002000) { /* 2.0 */
+		/* Enable VBUS detection and power up the PHY. */
+		OTG_FS_GCCFG = OTG_GCCFG_VBDEN | OTG_GCCFG_PWRDWN;
+		DWC_OTG_GOTGCTL(USB_OTG_FS_BASE) |= DWC_OTG_GOTGCTL_BVALOEN |
+										DWC_OTG_GOTGCTL_BVALOVAL;
+	} else { /* 1.x */
+		/* Enable VBUS sensing in device mode and power up the PHY. */
+		OTG_FS_GCCFG = OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
+	}
+
 	dwc_otg_init(&_usbd_dev);
 
 	return &_usbd_dev;

--- a/lib/usbd/backend/usbd_stm32_otg_hs.c
+++ b/lib/usbd/backend/usbd_stm32_otg_hs.c
@@ -67,6 +67,16 @@ static usbd_device *stm32_otg_hs_usbd_init(void)
 	private_data.ep_count = ENDPOINT_COUNTS;
 	_usbd_dev.backend_data = &private_data;
 
+	if (OTG_HS_CID >= 0x00002000) { /* 2.0 */
+		/* Enable VBUS detection and power up the PHY. */
+		OTG_HS_GCCFG = OTG_GCCFG_VBDEN | OTG_GCCFG_PWRDWN;
+		DWC_OTG_GOTGCTL(USB_OTG_HS_BASE) |= DWC_OTG_GOTGCTL_BVALOEN |
+										DWC_OTG_GOTGCTL_BVALOVAL;
+	} else { /* 1.x */
+		/* Enable VBUS sensing in device mode and power up the PHY. */
+		OTG_HS_GCCFG = OTG_GCCFG_VBUSBSEN | OTG_GCCFG_PWRDWN;
+	}
+
 	dwc_otg_init(&_usbd_dev);
 
 	return &_usbd_dev;

--- a/lib/usbh/backend/usbh_dwc_otg.c
+++ b/lib/usbh/backend/usbh_dwc_otg.c
@@ -140,8 +140,6 @@ void usbh_dwc_otg_init(usbh_host *host)
 	REBASE(OTG_PCGCCTL) = 0; /* Restart the PHY clock. */
 	REBASE(OTG_GINTSTS) = 0xFFFFFFFF;
 	REBASE(OTG_HPRT) |= OTG_HPRT_PPWR;
-	REBASE(OTG_GCCFG) = OTG_GCCFG_PWRDWN | OTG_GCCFG_NOVBUSSENS |
-						OTG_GCCFG_VBUSASEN | OTG_GCCFG_VBUSBSEN;
 
 	LOG_LN("DWC_OTG init complete");
 }

--- a/lib/usbh/backend/usbh_stm32_otg_fs.c
+++ b/lib/usbh/backend/usbh_stm32_otg_fs.c
@@ -18,6 +18,7 @@
  */
 
 #include "dwc_otg-private.h"
+#include <unicore-mx/stm32/otg_fs.h>
 #include <unicore-mx/stm32/memorymap.h>
 
 static usbh_host host;
@@ -44,6 +45,15 @@ static usbh_dwc_otg_priv private_data = {
 static usbh_host *init(void)
 {
 	host.backend_data = &private_data;
+
+	if (OTG_FS_CID >= 0x00002000) { /* 2.0 */
+		OTG_FS_GCCFG = OTG_GCCFG_VBDEN | OTG_GCCFG_PWRDWN;
+		OTG_FS_GOTGCTL |= OTG_GOTGCTL_AVALOEN |
+										OTG_GOTGCTL_AVALOVAL;
+	} else { /* 1.x */
+		OTG_FS_GCCFG = OTG_GCCFG_VBUSASEN | OTG_GCCFG_PWRDWN;
+	}
+
 	usbh_dwc_otg_init(&host);
 
 	return &host;


### PR DESCRIPTION
Also, DCTL.SDIS bit is set by default.

Originally raised by @davids5 in https://github.com/libopencm3/libopencm3/pull/681

Tesed:
- STM32F105 (PHY-FS) (CID = 1.1) - succes (@kuldeepdhaka)
- STM32F407 (PHY-FS) (CID = 1.1)  - success (@kuldeepdhaka)
- STM32F429 (PHY-HS) (CID = 1.2) - success (@brabo)
- STM32F746 (PHY-FS) (CID = 2.0) - success (@kuldeepdhaka, @danielinux)

Not Tested:
- STM32F446 (CID = 2.0)
- STMF32469 (CID = 2.0)

Edit1: Added STM32F429
Edit2: Added CID version (and corrected STM32F407 PHY type)
Edit3: Added STM32F746 and Tester
