### PR TITLE
nrf/51: Fixed some uart issues.

### DIFF
--- a/include/unicore-mx/nrf/51/uart.h
+++ b/include/unicore-mx/nrf/51/uart.h
@@ -125,7 +125,7 @@ enum uart_baud {
 
 #define UART_PSEL_OFF			(0xff)
 #define UART_MAX_PIN			(31)
-#define UART_PSEL_VAL(p)		((p) < UART_MAX_PIN ? (p) : 0xffffffff)
+#define UART_PSEL_VAL(p)		((p) <= UART_MAX_PIN ? (p) : 0xffffffff)
 
 
 BEGIN_DECLS


### PR DESCRIPTION
1. Fixed synchronous transfer. Needed to clear the event before
   proceeding.
2. Reduced the amount of code duplication between uart_send_buffer and
   uart_send_string, by moving some code to common macros.
