### PR TITLE
nrf/51: Common Peripheral Interface

### DIFF
--- a/include/unicore-mx/nrf/51/memorymap.h
+++ b/include/unicore-mx/nrf/51/memorymap.h
@@ -41,6 +41,8 @@
  * from the standard MPU
  */
 #define NRF_MPU_BASE			(APB_BASE)
+#define POWER_BASE			(APB_BASE)
+#define CLOCK_BASE			(APB_BASE)
 
 /* 2.4 GHz Radio */
 #define RADIO_BASE			(APB_BASE + 0x1000)

--- a/include/unicore-mx/nrf/51/periph.h
+++ b/include/unicore-mx/nrf/51/periph.h
@@ -1,0 +1,154 @@
+/*
+ * This file is part of the unicore-mx project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NRF51_PERIPH_H
+#define NRF51_PERIPH_H
+
+#include <unicore-mx/cm3/common.h>
+#include <unicore-mx/cm3/nvic.h>
+#include <unicore-mx/nrf/memorymap.h>
+
+/* Common Peripheral Interface.
+ * The implementation only applies to peripherals on APB
+ * bus, which for this part excludes only GPIO.
+ */
+
+/* Peripheral IDs
+ *
+ * For peripherals on the APB bus there is a direct relationship between its ID
+ * and its base address. A peripheral with base address 0x40000000 is therefore
+ * assigned ID=0, and a peripheral with base address 0x40001000 is assigned
+ * ID=1. The peripheral with base address 0x4001F000 is assigned ID=31
+ */
+
+#define PERIPH_CLOCK_ID			(0x00)
+#define PERIPH_POWER_ID			(0x00)
+#define PERIPH_MPU_ID			(0x00)
+#define PERIPH_RADIO_ID			(0x01)
+#define PERIPH_UART_ID			(0x02)
+#define PERIPH_SPI0_ID			(0x03)
+#define PERIPH_TWI0_ID			(0x03)
+#define PERIPH_I2C0_ID			(0x03)
+#define PERIPH_SPI1_ID			(0x04)
+#define PERIPH_SPIS1_ID			(0x04)
+#define PERIPH_TWI1_ID			(0x04)
+#define PERIPH_I2C1_ID			(0x04)
+#define PERIPH_GPIOTE_ID			(0x06)
+#define PERIPH_ADC_ID			(0x07)
+#define PERIPH_TIMER0_ID			(0x08)
+#define PERIPH_TIMER1_ID			(0x09)
+#define PERIPH_TIMER2_ID			(0x0a)
+#define PERIPH_RTC0_ID			(0x0b)
+#define PERIPH_TEMP_ID			(0x0c)
+#define PERIPH_RNG_ID			(0x0d)
+#define PERIPH_ECB_ID			(0x0e)
+#define PERIPH_AAR_ID			(0x0f)
+#define PERIPH_CCM_ID			(0x0f)
+#define PERIPH_WDT_ID			(0x10)
+#define PERIPH_RTC1_ID			(0x11)
+#define PERIPH_QDEC_ID			(0x12)
+#define PERIPH_LPCOMP_ID			(0x13)
+#define PERIPH_SWI0_ID			(0x14)
+#define PERIPH_SWI1_ID			(0x15)
+#define PERIPH_SWI2_ID			(0x16)
+#define PERIPH_SWI3_ID			(0x17)
+#define PERIPH_SWI4_ID			(0x18)
+#define PERIPH_SWI5_ID			(0x19)
+#define PERIPH_NVMC_ID			(0x1e)
+#define PERIPH_PPI_ID			(0x1f)
+
+#define periph_base_from_id(periph_id)			(ABP_BASE + 0x1000 * (periph_id))
+#define periph_id_from_base(base)			(((base) - APB_BASE) >> 12)
+#define periph_base_from_reg(reg)			(((uint32_t)&reg) & 0xfffff000)
+
+/*
+ * Tasks are used to trigger actions in a peripheral, for example, to start a
+ * particular behavior. A peripheral can implement multiple tasks with each
+ * task having a separate register in that peripheral's task register group.
+ *
+ * A task is triggered when firmware writes a '1' to the task register or when
+ * the peripheral itself, or another peripheral, toggles the corresponding task
+ * signal.
+ */
+
+/** Starting address of all the tasks in the peripheral. */
+#define PERIPH_TASK_OFFSET			(0x000)
+
+/*
+ * Events are used to notify peripherals and the CPU about events that have
+ * happened, for example, a state change in a peripheral. A peripheral may
+ * generate multiple events with each event having a separate register in that
+ * peripheral’s event register group.  An event is generated when the
+ * peripheral itself toggles the corresponding event signal, whereupon the
+ * event register is updated to reflect that the event has been generated.
+ */
+
+/** Starting address of all the events in the peripheral. */
+#define PERIPH_EVENT_OFFSET			(0x100)
+
+#define periph_trigger_task(task)			(task) = (1)
+
+/* All peripherals on the APB bus support interrupts. A peripheral only
+ * occupies one interrupt, and the interrupt number follows the peripheral ID,
+ * for example, the peripheral with ID=4 is connected to interrupt number 4 in
+ * the Nested Vector Interrupt Controller (NVIC).
+ */
+
+#define periph_enable_irq(base)			nvic_enable_irq(periph_id_from_base(base))
+#define periph_disable_irq(base)			nvic_disable_irq(periph_id_from_base(base))
+
+/* Common regisgers. Not all peripherals have these registers, but when they
+ * are present, they are at this offset.
+ */
+#define PERIPH_SHORTS_OFFSET			(0x200)
+#define PERIPH_INTEN_OFFSET			(0x300)
+#define PERIPH_INTENSET_OFFSET			(0x304)
+#define PERIPH_INTENCLR_OFFSET			(0x308)
+
+#define periph_shorts(base)			MMIO32((base) + PERIPH_SHORTS_OFFSET)
+#define periph_inten(base)			MMIO32((base) + PERIPH_INTEN_OFFSET)
+#define periph_intenset(base)			MMIO32((base) + PERIPH_INTENSET_OFFSET)
+#define periph_intenclr(base)			MMIO32((base) + PERIPH_INTENCLR_OFFSET)
+
+#define periph_enable_shorts(base, shorts)			periph_shorts(base) |= (shorts)
+#define periph_disable_shorts(base, shorts)			periph_shorts(base) &= (~(shorts))
+#define periph_clear_shorts(base)			periph_shorts(base) = (0)
+
+#define periph_enable_interrupts(base, mask)			periph_intenset(base) = (mask)
+#define periph_disable_interrupts(base, mask)			periph_intenclr(base) = (mask)
+#define periph_clear_interrupts(base)			periph_intenclr(base) = (0xffffffff)
+
+/* Each event implemented in the peripheral is associated with a specific bit
+ * position in the INTEN, INTENSET and INTENCLR registers. The correct bit
+ * position can be derived from the event's address. The event on address 0x100
+ * is associated with bit 0 in the INTEN register, the event at address 0x104
+ * is associated with bit 1, and so on. The event at address 0x17C is
+ * identified with bit 31 in the INTEN register. This pattern effectively
+ * limits the maximum number of events in a peripheral to 32.
+ */
+#define periph_event_inten_bit(event)			((((uint32_t)&event) & 0xff) >> 2)
+
+#define periph_enable_event_interrupt(event)			periph_enable_interrupts(periph_base_from_reg(event), periph_event_inten_bit(event))
+#define periph_disable_event_interrupt(event)			periph_disable_interrupts(periph_base_from_reg(event), periph_event_inten_bit(event))
+#define periph_clear_event(event)			(event) = (0)
+
+#define periph_wait_event(event) do {\
+	while(!event);\
+	periph_clear_event(event);\
+} while (0)
+
+#endif  /* NRF51_PERIPH_H */

--- a/include/unicore-mx/nrf/51/power.h
+++ b/include/unicore-mx/nrf/51/power.h
@@ -20,6 +20,7 @@
 
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/nrf/memorymap.h>
+#include <unicore-mx/nrf/periph.h>
 
 /* Tasks */
 #define POWER_TASK_CONSTLAT			MMIO32(POWER_BASE + 0x078)
@@ -29,8 +30,8 @@
 #define POWER_EVENT_POFWARN			MMIO32(POWER_BASE + 0x108)
 
 /* Registers */
-#define POWER_INTENSET			MMIO32(POWER_BASE + 0x304)
-#define POWER_INTENCLR			MMIO32(POWER_BASE + 0x308)
+#define POWER_INTENSET			periph_intenset(POWER_BASE)
+#define POWER_INTENCLR			periph_intenclr(POWER_BASE)
 #define POWER_RESETREAS			MMIO32(POWER_BASE + 0x400)
 #define POWER_RAMSTATUS			MMIO32(POWER_BASE + 0x428)
 #define POWER_SYSTEMOFF			MMIO32(POWER_BASE + 0x500)

--- a/include/unicore-mx/nrf/51/radio.h
+++ b/include/unicore-mx/nrf/51/radio.h
@@ -20,6 +20,7 @@
 
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/nrf/memorymap.h>
+#include <unicore-mx/nrf/periph.h>
 
 /* 2.4 GHz Radio */
 
@@ -48,9 +49,9 @@
 
 /* Registers */
 
-#define RADIO_SHORTS			MMIO32(RADIO_BASE + 0x200)
-#define RADIO_INTENSET			MMIO32(RADIO_BASE + 0x304)
-#define RADIO_INTENCLR			MMIO32(RADIO_BASE + 0x308)
+#define RADIO_SHORTS			periph_shorts(RADIO_BASE)
+#define RADIO_INTENSET			periph_intenset(RADIO_BASE)
+#define RADIO_INTENCLR			periph_intenclr(RADIO_BASE)
 #define RADIO_CRCSTATUS			MMIO32(RADIO_BASE + 0x400)
 #define RADIO_RXMATCH			MMIO32(RADIO_BASE + 0x408)
 #define RADIO_RXCRC			MMIO32(RADIO_BASE + 0x40C)
@@ -239,6 +240,9 @@
 /* Override 4 register has special bit and the override value is masked. */
 #define RADIO_OVERRIDE4_ENABLE			(1 << 31)
 #define RADIO_OVERRIDE4_OVERRIDE_MASK			(0x0fffffff)
+
+#define RADIO_POWER_ENABLED			(1)
+#define RADIO_POWER_DISABLED			(0)
 
 /* Bluetooth Low Energy parameters */
 #define RADIO_BLE_TIFS			(150)

--- a/include/unicore-mx/nrf/51/rtc.h
+++ b/include/unicore-mx/nrf/51/rtc.h
@@ -20,6 +20,7 @@
 
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/nrf/memorymap.h>
+#include <unicore-mx/nrf/periph.h>
 
 /* Only two RTCs on this device. */
 #define RTC0			RTC0_BASE
@@ -65,15 +66,15 @@
 #define RTC1_EVENT_COMPARE3			RTC_EVENT_COMPARE(RTC1, 3)
 
 /* Registers */
-#define RTC_INTEN(rtc)			MMIO32((rtc) + 0x300)
+#define RTC_INTEN(rtc)			periph_inten(rtc)
 #define RTC0_INTEN			RTC_INTEN(RTC0)
 #define RTC1_INTEN			RTC_INTEN(RTC1)
 
-#define RTC_INTENSET(rtc)			MMIO32((rtc) + 0x304)
+#define RTC_INTENSET(rtc)			periph_intenset(rtc)
 #define RTC0_INTENSET			RTC_INTENSET(RTC0)
 #define RTC1_INTENSET			RTC_INTENSET(RTC1)
 
-#define RTC_INTENCLR(rtc)			MMIO32((rtc) + 0x308)
+#define RTC_INTENCLR(rtc)			periph_intenclr(rtc)
 #define RTC0_INTENCLR			RTC_INTENCLR(RTC0)
 #define RTC1_INTENCLR			RTC_INTENCLR(RTC1)
 
@@ -125,10 +126,11 @@
 
 BEGIN_DECLS
 
+#define rtc_enable_interrupts			periph_enable_interrupts
+#define rtc_disable_interrupts			periph_disable_interrupts
+
 void rtc_set_prescaler(uint32_t rtc, uint16_t presc);
 uint32_t rtc_get_counter(uint32_t rtc);
-void rtc_enable_interrupts(uint32_t rtc, uint32_t mask);
-void rtc_disable_interrupts(uint32_t rtc, uint32_t mask);
 void rtc_enable_events(uint32_t rtc, uint32_t mask);
 void rtc_disable_events(uint32_t rtc, uint32_t mask);
 void rtc_start(uint32_t rtc);

--- a/include/unicore-mx/nrf/51/timer.h
+++ b/include/unicore-mx/nrf/51/timer.h
@@ -20,6 +20,7 @@
 
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/nrf/memorymap.h>
+#include <unicore-mx/nrf/periph.h>
 
 /* Timer/Counter */
 
@@ -103,17 +104,17 @@
 
 /* Registers */
 
-#define TIMER_SHORTS(T)			MMIO32((T) + 0x200)
+#define TIMER_SHORTS(T)			periph_shorts(T)
 #define TIMER0_SHORTS			TIMER_SHORTS(TIMER0)
 #define TIMER1_SHORTS			TIMER_SHORTS(TIMER1)
 #define TIMER2_SHORTS			TIMER_SHORTS(TIMER2)
 
-#define TIMER_INTENSET(T)			MMIO32((T) + 0x304)
+#define TIMER_INTENSET(T)			periph_intenset(T)
 #define TIMER0_INTENSET			TIMER_INTENSET(TIMER0)
 #define TIMER1_INTENSET			TIMER_INTENSET(TIMER1)
 #define TIMER2_INTENSET			TIMER_INTENSET(TIMER2)
 
-#define TIMER_INTENCLR(T)			MMIO32((T) + 0x308)
+#define TIMER_INTENCLR(T)			periph_intenclr(T)
 #define TIMER0_INTENCLR			TIMER_INTENCLR(TIMER0)
 #define TIMER1_INTENCLR			TIMER_INTENCLR(TIMER1)
 #define TIMER2_INTENCLR			TIMER_INTENCLR(TIMER2)
@@ -191,6 +192,11 @@ enum timer_bitmode {
 
 BEGIN_DECLS
 
+#define timer_enable_shorts			periph_enable_shorts
+#define timer_disable_shorts			periph_disable_shorts
+#define timer_enable_interrupts			periph_enable_interrupts
+#define timer_disable_interrupts			periph_disable_interrupts
+
 void timer_set_mode(uint32_t timer, enum timer_mode mode);
 void timer_set_bitmode(uint32_t timer, enum timer_bitmode bitmode);
 void timer_start(uint32_t timer);
@@ -198,10 +204,6 @@ void timer_stop(uint32_t timer);
 void timer_clear(uint32_t timer);
 void timer_set_prescaler(uint32_t timer, uint8_t presc);
 void timer_set_compare(uint32_t timer, uint8_t compare_num, uint32_t compare_val);
-void timer_enable_shorts(uint32_t timer, uint32_t shorts);
-void timer_disable_shorts(uint32_t timer, uint32_t shorts);
-void timer_enable_interrupts(uint32_t timer, uint32_t interrupts);
-void timer_disable_interrupts(uint32_t timer, uint32_t interrupts);
 
 END_DECLS
 

--- a/include/unicore-mx/nrf/51/uart.h
+++ b/include/unicore-mx/nrf/51/uart.h
@@ -20,6 +20,7 @@
 
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/nrf/memorymap.h>
+#include <unicore-mx/nrf/periph.h>
 
 /* Universal Asynchronous Receiver/Transmitter */
 
@@ -57,9 +58,9 @@
 
 /* Registers */
 
-#define UART_INTEN(uart)			MMIO32((uart) + 0x300)
-#define UART_INTENSET(uart)			MMIO32((uart) + 0x304)
-#define UART_INTENCLR(uart)			MMIO32((uart) + 0x308)
+#define UART_INTEN(uart)			periph_inten(uart)
+#define UART_INTENSET(uart)			periph_intenset(uart)
+#define UART_INTENCLR(uart)			periph_intenclr(uart)
 #define UART_ERRORSRC(uart)			MMIO32((uart) + 0x480)
 #define UART_ENABLE(uart)			MMIO32((uart) + 0x500)
 #define UART_PSELRTS(uart)			MMIO32((uart) + 0x508)
@@ -99,7 +100,8 @@
 #define UART_ERRORSRC_FRAMING			(1 << 2)
 #define UART_ERRORSRC_BREAK			(1 << 3)
 
-#define UART_ENABLE_ENABLE			(4)
+#define UART_ENABLE_ENABLED			(4)
+#define UART_ENABLE_DISABLED			(0)
 
 enum uart_baud {
 	UART_BAUD_1200 = 0x0004F000,
@@ -130,8 +132,9 @@ enum uart_baud {
 
 BEGIN_DECLS
 
-void uart_enable_interrupts(uint32_t uart, uint32_t mask);
-void uart_disable_interrupts(uint32_t uart, uint32_t mask);
+#define uart_enable_interrupts			periph_enable_interrupts
+#define uart_disable_interrupts			periph_disable_interrupts
+
 void uart_enable(uint32_t uart);
 void uart_disable(uint32_t uart);
 void uart_configure(uint32_t uart,

--- a/include/unicore-mx/nrf/periph.h
+++ b/include/unicore-mx/nrf/periph.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the unicore-mx project.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NRF_PERIPH_H
+#define NRF_PERIPH_H
+
+#if defined(NRF51)
+#	include <unicore-mx/nrf/51/periph.h>
+#else
+#	error "Processor family not defined."
+#endif
+
+#endif

--- a/lib/nrf/51/clock.c
+++ b/lib/nrf/51/clock.c
@@ -26,6 +26,7 @@
  */
 
 #include <unicore-mx/nrf/clock.h>
+#include <unicore-mx/nrf/periph.h>
 
 /** @brief Start Low Frequency Clock
  *
@@ -33,7 +34,7 @@
  */
 void clock_start_lfclk(bool wait)
 {
-	CLOCK_TASK_LFCLKSTART = 1;
+	periph_trigger_task(CLOCK_TASK_LFCLKSTART);
 	if (wait) {
 		while(!(CLOCK_LFCLKSTAT & CLOCK_LFCLKSTAT_STATE));
 	}
@@ -42,7 +43,7 @@ void clock_start_lfclk(bool wait)
 /** @brief Stop Low Frequency Clock */
 void clock_stop_lfclk()
 {
-	CLOCK_TASK_LFCLKSTOP = 1;
+	periph_trigger_task(CLOCK_TASK_LFCLKSTOP);
 }
 
 /** @brief Start High Frequency Crystal Oscillator.
@@ -53,7 +54,7 @@ void clock_stop_lfclk()
  */
 void clock_start_hfclk(bool wait)
 {
-	CLOCK_TASK_HFCLKSTART = 1;
+	periph_trigger_task(CLOCK_TASK_HFCLKSTART);
 	if (wait) {
 		while(!(CLOCK_HFCLKSTAT & CLOCK_HFCLKSTAT_STATE));
 	}
@@ -62,7 +63,7 @@ void clock_start_hfclk(bool wait)
 /** @brief Stop High Frequency Crystal Oscillator */
 void clock_stop_hfclk()
 {
-	CLOCK_TASK_HFCLKSTOP = 1;
+	periph_trigger_task(CLOCK_TASK_HFCLKSTOP);
 }
 
 /** @brief Select nominal frequency of external crystal for HFCLK.

--- a/lib/nrf/51/radio.c
+++ b/lib/nrf/51/radio.c
@@ -119,13 +119,13 @@ void radio_disable_crc(void)
 /** @brief Enable the peripheral. */
 void radio_enable(void)
 {
-	RADIO_POWER = 1;
+	RADIO_POWER = RADIO_POWER_ENABLED;
 }
 
 /** @brief Disable the peripheral. */
 void radio_disable(void)
 {
-	RADIO_POWER = 0;
+	RADIO_POWER = RADIO_POWER_DISABLED;
 }
 
 
@@ -264,7 +264,7 @@ void radio_set_packet_ptr(uint8_t* packet_ptr)
  */
 void radio_enable_shorts(uint16_t shorts)
 {
-	RADIO_SHORTS |= shorts;
+	periph_enable_shorts(RADIO_BASE, shorts);
 }
 
 /* @brief Disable shortcuts
@@ -273,35 +273,35 @@ void radio_enable_shorts(uint16_t shorts)
  */
 void radio_disable_shorts(uint16_t shorts)
 {
-	RADIO_SHORTS &= ~shorts;
+	periph_disable_shorts(RADIO_BASE, shorts);
 }
 
 /* @brief Clear all shortcuts */
 void radio_clear_shorts(void)
 {
-	RADIO_SHORTS = 0;
+	periph_clear_shorts(RADIO_BASE);
 }
 
 /* @brief Enable radio Transmitter */
 void radio_enable_tx(void)
 {
-	RADIO_TASK_TXEN = 1;
+	periph_trigger_task(RADIO_TASK_TXEN);
 }
 
 /* @brief Enable radio Receiver */
 void radio_enable_rx(void)
 {
-	RADIO_TASK_RXEN = 1;
+	periph_trigger_task(RADIO_TASK_RXEN);
 }
 
 /* @brief Enable interrupts by mask */
 void radio_enable_interrupts(uint32_t interrupts)
 {
-	RADIO_INTENSET = interrupts;
+	periph_enable_interrupts(RADIO_BASE, interrupts);
 }
 
 /* @brief Disable interrupts by mask */
 void radio_disable_interrupts(uint32_t interrupts)
 {
-	RADIO_INTENCLR = interrupts;
+	periph_disable_interrupts(RADIO_BASE, interrupts);
 }

--- a/lib/nrf/51/rtc.c
+++ b/lib/nrf/51/rtc.c
@@ -48,26 +48,6 @@ uint32_t rtc_get_counter(uint32_t rtc)
 	return RTC_COUNTER(rtc);
 }
 
-/** @brief Enable peripheral interrupts
- *
- * @param[in] rtc uint32_t RTC base
- * @param[in] mask uint32_t which interrupts to enable
- */
-void rtc_enable_interrupts(uint32_t rtc, uint32_t mask)
-{
-	RTC_INTENSET(rtc) = mask;
-}
-
-/** @brief Disable peripheral interrupts
- *
- * @param[in] rtc uint32_t RTC base
- * @param[in] mask uint32_t which interrupts to disable
- */
-void rtc_disable_interrupts(uint32_t rtc, uint32_t mask)
-{
-	RTC_INTENCLR(rtc) = mask;
-}
-
 /** @brief Enable events
  *
  * @param[in] rtc uint32_t RTC base
@@ -94,7 +74,7 @@ void rtc_disable_events(uint32_t rtc, uint32_t mask)
  */
 void rtc_start(uint32_t rtc)
 {
-	RTC_TASK_START(rtc) = 1;
+	periph_trigger_task(RTC_TASK_START(rtc));
 }
 
 /** @brief Stop the RTC
@@ -103,7 +83,7 @@ void rtc_start(uint32_t rtc)
  */
 void rtc_stop(uint32_t rtc)
 {
-	RTC_TASK_STOP(rtc) = 1;
+	periph_trigger_task(RTC_TASK_STOP(rtc));
 }
 
 /** @brief Clear the RTC
@@ -112,7 +92,7 @@ void rtc_stop(uint32_t rtc)
  */
 void rtc_clear(uint32_t rtc)
 {
-	RTC_TASK_CLEAR(rtc) = 1;
+	periph_trigger_task(RTC_TASK_CLEAR(rtc));
 }
 
 /** @brief Set compare register

--- a/lib/nrf/51/timer.c
+++ b/lib/nrf/51/timer.c
@@ -53,7 +53,7 @@ void timer_set_bitmode(uint32_t timer, enum timer_bitmode bitmode)
  */
 void timer_start(uint32_t timer)
 {
-	TIMER_TASK_START(timer) = 1;
+	periph_trigger_task(TIMER_TASK_START(timer));
 }
 
 /** @brief Stop the timer
@@ -62,7 +62,7 @@ void timer_start(uint32_t timer)
  */
 void timer_stop(uint32_t timer)
 {
-	TIMER_TASK_STOP(timer) = 1;
+	periph_trigger_task(TIMER_TASK_STOP(timer));
 }
 
 /** @brief Clear the timer
@@ -71,7 +71,7 @@ void timer_stop(uint32_t timer)
  */
 void timer_clear(uint32_t timer)
 {
-	TIMER_TASK_CLEAR(timer) = 1;
+	periph_trigger_task(TIMER_TASK_CLEAR(timer));
 }
 
 /** @brief Set prescaler value
@@ -97,44 +97,4 @@ void timer_set_compare(uint32_t timer, uint8_t compare_num, uint32_t compare_val
 	}
 
 	TIMER_CC(timer, compare_num) = compare_val;
-}
-
-/** @brief Enable shortcuts
- *
- * @param[in] timer uint32_t timer base
- * @param[in] shorts uint32_t mask of the shortcuts to enable
- */
-void timer_enable_shorts(uint32_t timer, uint32_t shorts)
-{
-	TIMER_SHORTS(timer) |= shorts;
-}
-
-/** @brief Disable shortcuts
- *
- * @param[in] timer uint32_t timer base
- * @param[in] shorts uint32_t mask of the shortcuts to disable
- */
-void timer_disable_shorts(uint32_t timer, uint32_t shorts)
-{
-	TIMER_SHORTS(timer) &= ~shorts;
-}
-
-/** @brief Enable interrupts
- *
- * @param[in] timer uint32_t timer base
- * @param[in] interrupts uint32_t mask of the interrupts to enable
- */
-void timer_enable_interrupts(uint32_t timer, uint32_t interrupts)
-{
-	TIMER_INTENSET(timer) = interrupts;
-}
-
-/** @brief Disable interrupts
- *
- * @param[in] timer uint32_t timer base
- * @param[in] interrupts uint32_t mask of the interrupts to disable
- */
-void timer_disable_interrupts(uint32_t timer, uint32_t interrupts)
-{
-	TIMER_INTENCLR(timer) = interrupts;
 }


### PR DESCRIPTION
These are registers and convenient definitions that work for all APB peripherals on nrf51. I put everything into macros, because most of them are used from similar functions in other peripherals and I didn't want to create long call chains over something very trivial.