### PR TITLE
!warnings:ARM compiler - fixed code vs inconsisting with standart C, …

### DIFF
--- a/lib/usbd/usbd_private.h
+++ b/lib/usbd/usbd_private.h
@@ -309,7 +309,8 @@ inline void mark_ep_as_free(usbd_device *dev, uint8_t ep_addr, bool yes);
  * @param[in] ep_addr Endpoint address (including direction)
  * @return mask
  */
-inline uint32_t ep_free_mask(uint8_t ep_addr)
+static inline 
+uint32_t ep_free_mask(uint8_t ep_addr)
 {
 	uint32_t num = ENDPOINT_NUMBER(ep_addr);
 
@@ -408,7 +409,8 @@ inline void usbd_handle_reset(usbd_device *dev)
  * @param[in] dev USB Device
  * @param[in] ep_addr Endpoint (including direction)
  */
-inline bool is_ep_free(usbd_device *dev, uint8_t ep_addr)
+static inline 
+bool is_ep_free(usbd_device *dev, uint8_t ep_addr)
 {
 	return !!(dev->urbs.ep_free & ep_free_mask(ep_addr));
 }
@@ -419,7 +421,8 @@ inline bool is_ep_free(usbd_device *dev, uint8_t ep_addr)
  * @param[in] ep_addr Endpoint address (including direction)
  * @param[in] yes Yes (if true, mark it as unused)
  */
-inline void mark_ep_as_free(usbd_device *dev, uint8_t ep_addr, bool yes)
+static inline 
+void mark_ep_as_free(usbd_device *dev, uint8_t ep_addr, bool yes)
 {
 	uint32_t mask = ep_free_mask(ep_addr);
 	if (yes) {

--- a/lib/usbd/usbd_transfer.c
+++ b/lib/usbd/usbd_transfer.c
@@ -670,7 +670,7 @@ static void _control_status_callback(usbd_device *dev,
 		return;
 	}
 
-	usbd_control_transfer_callback callback = transfer->user_data;
+	usbd_control_transfer_callback callback = (usbd_control_transfer_callback)transfer->user_data;
 	if (callback != NULL) {
 		callback(dev, NULL);
 	}
@@ -720,7 +720,7 @@ static void _control_data_callback(usbd_device *dev,
 		return;
 	}
 
-	usbd_control_transfer_callback callback = transfer->user_data;
+	usbd_control_transfer_callback callback = (usbd_control_transfer_callback)transfer->user_data;
 	usbd_control_transfer_feedback feedback = USBD_CONTROL_TRANSFER_OK;
 
 	if (callback != NULL) {
@@ -897,7 +897,7 @@ void *usbd_urb_get_buffer_pointer(usbd_device *dev, usbd_urb *urb, size_t len)
 		return transfer->buffer;
 	}
 
-	return transfer->buffer + transfer->transferred;
+	return (void*)((uintptr_t)transfer->buffer + transfer->transferred);
 }
 
 /**


### PR DESCRIPTION
fixed code vs inconsisting with standart C on Keil ARM compiler, that cause warnings pointer type mis-mutch, packed vs unpacked pointer type mis-mutch,

!no binary const - C standart not provide binary (0b)constants, so ARM compiler fail on it.

*              remove code with goto