### PR TITLE
stm32: add dma_get_number_of_data

### DIFF
--- a/include/unicore-mx/stm32/common/dma_common_f247.h
+++ b/include/unicore-mx/stm32/common/dma_common_f247.h
@@ -9,6 +9,7 @@ Ken Sarkies <ksarkies@internode.on.net>
 /*
  * Copyright (C) 2011 Fergus Noble <fergusnoble@gmail.com>
  * Copyright (C) 2012 Ken Sarkies <ksarkies@internode.on.net>
+ * Copyright (C) 2016 Daniel Gröber <dxld@darkboxed.org>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -611,6 +612,7 @@ void dma_disable_stream(uint32_t dma, uint8_t stream);
 void dma_set_peripheral_address(uint32_t dma, uint8_t stream, uint32_t address);
 void dma_set_memory_address(uint32_t dma, uint8_t stream, uint32_t address);
 void dma_set_memory_address_1(uint32_t dma, uint8_t stream, uint32_t address);
+uint16_t dma_get_number_of_data(uint32_t dma, uint8_t stream);
 void dma_set_number_of_data(uint32_t dma, uint8_t stream, uint16_t number);
 
 END_DECLS
@@ -621,4 +623,3 @@ END_DECLS
 #warning "dma_common_f247.h should not be included explicitly, only via dma.h"
 #endif
 /** @endcond */
-

--- a/include/unicore-mx/stm32/common/dma_common_l1f013.h
+++ b/include/unicore-mx/stm32/common/dma_common_l1f013.h
@@ -10,6 +10,7 @@ Piotr Esden-Tempski <piotr@esden.net>
 /*
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
  * Copyright (C) 2012 Piotr Esden-Tempski <piotr@esden.net>
+ * Copyright (C) 2016 Daniel Gröber <dxld@darkboxed.org>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -408,6 +409,7 @@ void dma_disable_channel(uint32_t dma, uint8_t channel);
 void dma_set_peripheral_address(uint32_t dma, uint8_t channel,
 				uint32_t address);
 void dma_set_memory_address(uint32_t dma, uint8_t channel, uint32_t address);
+uint16_t dma_get_number_of_data(uint32_t dma, uint8_t channel);
 void dma_set_number_of_data(uint32_t dma, uint8_t channel, uint16_t number);
 
 END_DECLS
@@ -420,4 +422,3 @@ END_DECLS
 /** @endcond */
 
 /**@}*/
-

--- a/lib/stm32/common/dma_common_f247.c
+++ b/lib/stm32/common/dma_common_f247.c
@@ -27,6 +27,7 @@ LGPL License Terms @ref lgpl_license
  */
 /*
  * Copyright (C) 2012 Ken Sarkies <ksarkies@internode.on.net>
+ * Copyright (C) 2016 Daniel Gröber <dxld@darkboxed.org>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -773,6 +774,20 @@ void dma_set_memory_address_1(uint32_t dma, uint8_t stream, uint32_t address)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief DMA Stream Get the Transfer Block Size
+
+@param[in] dma unsigned int32. DMA controller base address: DMA1 or DMA2
+@param[in] stream unsigned int8. Stream number: @ref dma_st_number
+@returns unsigned int16. Number of remaining data words to transfer (65535
+maximum).
+*/
+
+uint16_t dma_get_number_of_data(uint32_t dma, uint8_t stream)
+{
+	return DMA_SNDTR(dma, stream);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief DMA Stream Set the Transfer Block Size
 
 @note The DMA stream must be disabled before setting this count value. The count
@@ -789,4 +804,3 @@ void dma_set_number_of_data(uint32_t dma, uint8_t stream, uint16_t number)
 	DMA_SNDTR(dma, stream) = number;
 }
 /**@}*/
-

--- a/lib/stm32/common/dma_common_l1f013.c
+++ b/lib/stm32/common/dma_common_l1f013.c
@@ -19,6 +19,7 @@ LGPL License Terms @ref lgpl_license
  */
 /*
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2016 Daniel Gröber <dxld@darkboxed.org>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -414,6 +415,20 @@ void dma_set_memory_address(uint32_t dma, uint8_t channel, uint32_t address)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief DMA Channel Get the Transfer Block Size
+
+@param[in] dma unsigned int32. DMA controller base address: DMA1 or DMA2
+@param[in] channel unsigned int8. Channel number: 1-7 for DMA1 or 1-5 for DMA2
+@returns unsigned int16. Number of remaining data words to transfer (65535
+maximum).
+*/
+
+uint16_t dma_get_number_of_data(uint32_t dma, uint8_t channel)
+{
+	return DMA_CNDTR(dma, channel);
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief DMA Channel Set the Transfer Block Size
 
 @note The DMA channel must be disabled before setting this count value. The
@@ -430,4 +445,3 @@ void dma_set_number_of_data(uint32_t dma, uint8_t channel, uint16_t number)
 	DMA_CNDTR(dma, channel) = number;
 }
 /**@}*/
-


### PR DESCRIPTION
Just something that's convenient when you need to know how much has been transferred so far.

Find the PR useful.
Adds a function like EFM32 dma_get_number_of_data() for STM32.

Reference PR: https://github.com/libopencm3/libopencm3/pull/702.
Thanks to @DanielG