### PR TITLE
!usbd:out:zero - force generating IN transfer with zero len

### DIFF
--- a/lib/usbd/backend/usbd_dwc_otg.c
+++ b/lib/usbd/backend/usbd_dwc_otg.c
@@ -536,6 +536,10 @@ static void urb_submit_non_ep0(usbd_device *dev, usbd_urb *urb)
 				}
 			}
 		}
+		else if (transfer->length == 0){
+				// force transmit empty packet
+				pktcnt = 1;
+		}
 
 		REBASE(DWC_OTG_DIEPxTSIZ, ep_num) =
 					mc_from_flags(transfer->flags) |


### PR DESCRIPTION
URB with zero-len without USBD_FLAG_SHORT_PACKET now ommited. 

this behaviour  is conflicts with intention of manual short packets handling - for such case URB goes without USBD_FLAG_SHORT_PACKET, and zero-length MUST be achievable
