### PR TITLE
*stm32:CMSIS:gpio, rcc - compatibiluty vs CMSIS library 

### DIFF
--- a/include/libopencmsis/core_cm3.h
+++ b/include/libopencmsis/core_cm3.h
@@ -10,6 +10,7 @@
 #ifndef OPENCMSIS_CORECM3_H
 #define OPENCMSIS_CORECM3_H
 
+#include <unicore-mx/common/cmsis.h>
 #include <unicore-mx/cm3/common.h>
 #include <unicore-mx/cm3/cortex.h>
 #include <unicore-mx/cm3/memorymap.h>
@@ -88,6 +89,10 @@ static inline void NVIC_DisableIRQ(uint8_t irqn)
 
 /* stubs for efm32_int */
 
+//* looks like ARMCC have this by internals
+
+#if __CMSIS_USE==0
+#if defined ( __GNUC__ )
 static inline void __enable_irq(void)
 {
 	cm_enable_interrupts();
@@ -96,6 +101,8 @@ static inline void __disable_irq(void)
 {
 	cm_disable_interrupts();
 }
+#endif //defined ( __GNUC__ )
+#endif // __CMSIS_USE==0
 
 /* stubs for efm32_mpu FIXME */
 

--- a/include/unicore-mx/cm3/memorymap.h
+++ b/include/unicore-mx/cm3/memorymap.h
@@ -19,6 +19,7 @@
 #define UNICOREMX_CM3_MEMORYMAP_H
 
 /* --- ARM Cortex-M0, M3 and M4 specific definitions ----------------------- */
+#include <unicore-mx/common/cmsis.h>
 
 /* Private peripheral bus - Internal */
 #define PPBI_BASE                       (0xE0000000U)
@@ -37,7 +38,9 @@
 
 /* PPBI_BASE + 0x3000 (0xE000 3000 - 0xE000 DFFF): Reserved */
 
+#if !(__CMSIS_USE)
 #define SCS_BASE                        (PPBI_BASE + 0xE000)
+#endif
 
 /* PPBI_BASE + 0xF000 (0xE000 F000 - 0xE003 FFFF): Reserved */
 
@@ -57,6 +60,7 @@
 /* SYS_TICK: System Timer */
 #define SYS_TICK_BASE                   (SCS_BASE + 0x0010)
 
+#if !(__CMSIS_USE)
 /* NVIC: Nested Vector Interrupt Controller */
 #define NVIC_BASE                       (SCS_BASE + 0x0100)
 
@@ -65,6 +69,8 @@
 
 /* MPU: Memory protection unit */
 #define MPU_BASE                        (SCS_BASE + 0x0D90)
+
+#endif// !(__CMSIS_USE)
 
 /* Those defined only on CM0*/
 #if defined(__ARM_ARCH_6M__)

--- a/include/unicore-mx/common/cmsis.h
+++ b/include/unicore-mx/common/cmsis.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+//* this header should provide CMSIS headers detection, to achieve compatibility on ones vs unicore headers
+
+#ifndef UNICOREMX_CMSIS_COMPAT_H
+#define UNICOREMX_CMSIS_COMPAT_H
+
+
+
+#ifndef __CMSIS_USE
+#if defined(__STM32F0xx_CMSIS_DEVICE_VERSION) \
+            || defined(__STM32F1xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F2xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F3xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F4xx_CMSIS_DEVICE_VERSION)\
+            || defined(__STM32F7xx_CMSIS_DEVICE_VERSION)
+#define __CMSIS_USE	1
+#else
+#define __CMSIS_USE	0
+#endif
+#endif
+
+#if defined(HAL_MODULE_ENABLED) || defined(HAL_GPIO_MODULE_ENABLED)
+#define __HAL_USE	1
+#else
+#define __HAL_USE	0
+#endif
+
+
+#endif

--- a/include/unicore-mx/stm32/common/flash_common_f24.h
+++ b/include/unicore-mx/stm32/common/flash_common_f24.h
@@ -65,7 +65,7 @@
 
 /* --- FLASH_CR values ----------------------------------------------------- */
 
-#define FLASH_CR_LOCK			(1 << 31)
+#define FLASH_CR_LOCK			(1u << 31)
 #define FLASH_CR_ERRIE			(1 << 25)
 #define FLASH_CR_EOPIE			(1 << 24)
 #define FLASH_CR_STRT			(1 << 16)

--- a/include/unicore-mx/stm32/common/gpio_common_f234.h
+++ b/include/unicore-mx/stm32/common/gpio_common_f234.h
@@ -43,19 +43,27 @@ specific memorymap.h header before including this header file.*/
 @ingroup gpio_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define GPIOA				GPIO_PORT_A_BASE
 #define GPIOB				GPIO_PORT_B_BASE
 #define GPIOC				GPIO_PORT_C_BASE
 #define GPIOD				GPIO_PORT_D_BASE
 #define GPIOE				GPIO_PORT_E_BASE
 #define GPIOF				GPIO_PORT_F_BASE
+#define GPIOA_BASE  GPIO_PORT_A_BASE
+#define GPIOB_BASE  GPIO_PORT_B_BASE
+#define GPIOC_BASE  GPIO_PORT_C_BASE
+#define GPIOD_BASE  GPIO_PORT_D_BASE
+#define GPIOE_BASE  GPIO_PORT_E_BASE
+#define GPIOF_BASE  GPIO_PORT_F_BASE
+#endif
 
 /**@}*/
 
 /* --- GPIO registers for STM32F2, STM32F3 and STM32F4 --------------------- */
 
 /* Port mode register (GPIOx_MODER) */
-#define GPIO_MODER(port)		MMIO32((port) + 0x00)
+#define GPIO_MODER(port)		MMIO32(((uint32_t)port) + 0x00)
 #define GPIOA_MODER			GPIO_MODER(GPIOA)
 #define GPIOB_MODER			GPIO_MODER(GPIOB)
 #define GPIOC_MODER			GPIO_MODER(GPIOC)
@@ -64,7 +72,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_MODER			GPIO_MODER(GPIOF)
 
 /* Port output type register (GPIOx_OTYPER) */
-#define GPIO_OTYPER(port)		MMIO32((port) + 0x04)
+#define GPIO_OTYPER(port)		MMIO32(((uint32_t)port) + 0x04)
 #define GPIOA_OTYPER			GPIO_OTYPER(GPIOA)
 #define GPIOB_OTYPER			GPIO_OTYPER(GPIOB)
 #define GPIOC_OTYPER			GPIO_OTYPER(GPIOC)
@@ -73,7 +81,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_OTYPER			GPIO_OTYPER(GPIOF)
 
 /* Port output speed register (GPIOx_OSPEEDR) */
-#define GPIO_OSPEEDR(port)		MMIO32((port) + 0x08)
+#define GPIO_OSPEEDR(port)		MMIO32(((uint32_t)port) + 0x08)
 #define GPIOA_OSPEEDR			GPIO_OSPEEDR(GPIOA)
 #define GPIOB_OSPEEDR			GPIO_OSPEEDR(GPIOB)
 #define GPIOC_OSPEEDR			GPIO_OSPEEDR(GPIOC)
@@ -82,7 +90,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_OSPEEDR			GPIO_OSPEEDR(GPIOF)
 
 /* Port pull-up/pull-down register (GPIOx_PUPDR) */
-#define GPIO_PUPDR(port)		MMIO32((port) + 0x0c)
+#define GPIO_PUPDR(port)		MMIO32(((uint32_t)port) + 0x0c)
 #define GPIOA_PUPDR			GPIO_PUPDR(GPIOA)
 #define GPIOB_PUPDR			GPIO_PUPDR(GPIOB)
 #define GPIOC_PUPDR			GPIO_PUPDR(GPIOC)
@@ -91,7 +99,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_PUPDR			GPIO_PUPDR(GPIOF)
 
 /* Port input data register (GPIOx_IDR) */
-#define GPIO_IDR(port)			MMIO32((port) + 0x10)
+#define GPIO_IDR(port)			MMIO32(((uint32_t)port) + 0x10)
 #define GPIOA_IDR			GPIO_IDR(GPIOA)
 #define GPIOB_IDR			GPIO_IDR(GPIOB)
 #define GPIOC_IDR			GPIO_IDR(GPIOC)
@@ -100,7 +108,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_IDR			GPIO_IDR(GPIOF)
 
 /* Port output data register (GPIOx_ODR) */
-#define GPIO_ODR(port)			MMIO32((port) + 0x14)
+#define GPIO_ODR(port)			MMIO32(((uint32_t)port) + 0x14)
 #define GPIOA_ODR			GPIO_ODR(GPIOA)
 #define GPIOB_ODR			GPIO_ODR(GPIOB)
 #define GPIOC_ODR			GPIO_ODR(GPIOC)
@@ -109,7 +117,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_ODR			GPIO_ODR(GPIOF)
 
 /* Port bit set/reset register (GPIOx_BSRR) */
-#define GPIO_BSRR(port)			MMIO32((port) + 0x18)
+#define GPIO_BSRR(port)			MMIO32(((uint32_t)port) + 0x18)
 #define GPIOA_BSRR			GPIO_BSRR(GPIOA)
 #define GPIOB_BSRR			GPIO_BSRR(GPIOB)
 #define GPIOC_BSRR			GPIO_BSRR(GPIOC)
@@ -118,7 +126,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_BSRR			GPIO_BSRR(GPIOF)
 
 /* Port configuration lock register (GPIOx_LCKR) */
-#define GPIO_LCKR(port)			MMIO32((port) + 0x1c)
+#define GPIO_LCKR(port)			MMIO32(((uint32_t)port) + 0x1c)
 #define GPIOA_LCKR			GPIO_LCKR(GPIOA)
 #define GPIOB_LCKR			GPIO_LCKR(GPIOB)
 #define GPIOC_LCKR			GPIO_LCKR(GPIOC)
@@ -127,7 +135,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_LCKR			GPIO_LCKR(GPIOF)
 
 /* Alternate function low register (GPIOx_AFRL) */
-#define GPIO_AFRL(port)			MMIO32((port) + 0x20)
+#define GPIO_AFRL(port)			MMIO32(((uint32_t)port) + 0x20)
 #define GPIOA_AFRL			GPIO_AFRL(GPIOA)
 #define GPIOB_AFRL			GPIO_AFRL(GPIOB)
 #define GPIOC_AFRL			GPIO_AFRL(GPIOC)
@@ -136,7 +144,7 @@ specific memorymap.h header before including this header file.*/
 #define GPIOF_AFRL			GPIO_AFRL(GPIOF)
 
 /* Alternate function high register (GPIOx_AFRH) */
-#define GPIO_AFRH(port)			MMIO32((port) + 0x24)
+#define GPIO_AFRH(port)			MMIO32(((uint32_t)port) + 0x24)
 #define GPIOA_AFRH			GPIO_AFRH(GPIOA)
 #define GPIOB_AFRH			GPIO_AFRH(GPIOB)
 #define GPIOC_AFRH			GPIO_AFRH(GPIOC)
@@ -151,10 +159,14 @@ specific memorymap.h header before including this header file.*/
 /** @defgroup gpio_mode GPIO Pin Direction and Analog/Digital Mode
 @ingroup gpio_defines
 @{*/
+#if !(__HAL_USE)
 #define GPIO_MODE_INPUT			0x0
+#endif
 #define GPIO_MODE_OUTPUT		0x1
 #define GPIO_MODE_AF			0x2
+#if !(__HAL_USE)
 #define GPIO_MODE_ANALOG		0x3
+#endif
 /**@}*/
 
 /* --- GPIOx_OTYPER values ------------------------------------------------- */
@@ -208,7 +220,7 @@ specific memorymap.h header before including this header file.*/
 
 /* --- GPIOx_LCKR values --------------------------------------------------- */
 
-#define GPIO_LCKK			(1 << 16)
+//#define GPIO_LCKK			(1ul << 16)
 /* GPIOx_LCKR[15:0]: LCKy: Port x lock bit y (y = 0..15) */
 
 /* --- GPIOx_AFRL/H values ------------------------------------------------- */

--- a/include/unicore-mx/stm32/common/gpio_common_f24.h
+++ b/include/unicore-mx/stm32/common/gpio_common_f24.h
@@ -43,11 +43,18 @@ specific memorymap.h header before including this header file.*/
 @ingroup gpio_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define GPIOG				GPIO_PORT_G_BASE
 #define GPIOH				GPIO_PORT_H_BASE
 #define GPIOI				GPIO_PORT_I_BASE
 #define GPIOJ				GPIO_PORT_J_BASE
 #define GPIOK				GPIO_PORT_K_BASE
+#define GPIOG_BASE  GPIO_PORT_G_BASE
+#define GPIOH_BASE  GPIO_PORT_H_BASE
+#define GPIOI_BASE  GPIO_PORT_I_BASE
+#define GPIOJ_BASE  GPIO_PORT_J_BASE
+#define GPIOK_BASE  GPIO_PORT_K_BASE
+#endif
 /**@}*/
 
 /* --- GPIO registers for STM32F2, STM32F3 and STM32F4 --------------------- */

--- a/include/unicore-mx/stm32/common/usart_common_all.h
+++ b/include/unicore-mx/stm32/common/usart_common_all.h
@@ -39,12 +39,14 @@ specific memorymap.h header before including this header file.*/
 @ingroup STM32F_usart_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART1				USART1_BASE
 #define USART2				USART2_BASE
 #define USART3				USART3_BASE
 /**@}*/
 #define UART4				UART4_BASE
 #define UART5				UART5_BASE
+#endif
 
 /* --- Convenience defines ------------------------------------------------- */
 
@@ -54,9 +56,11 @@ specific memorymap.h header before including this header file.*/
 @ingroup STM32F_usart_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART_PARITY_NONE		0x00
 #define USART_PARITY_EVEN		USART_CR1_PCE
 #define USART_PARITY_ODD		(USART_CR1_PS | USART_CR1_PCE)
+#endif
 /**@}*/
 #define USART_PARITY_MASK		(USART_CR1_PS | USART_CR1_PCE)
 
@@ -66,9 +70,11 @@ specific memorymap.h header before including this header file.*/
 @ingroup STM32F_usart_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART_MODE_RX                   USART_CR1_RE
 #define USART_MODE_TX		        USART_CR1_TE
 #define USART_MODE_TX_RX		(USART_CR1_RE | USART_CR1_TE)
+#endif
 /**@}*/
 #define USART_MODE_MASK		        (USART_CR1_RE | USART_CR1_TE)
 
@@ -77,10 +83,12 @@ specific memorymap.h header before including this header file.*/
 @ingroup STM32F_usart_defines
 
 @{*/
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART_STOPBITS_1		USART_CR2_STOPBITS_1   /* 1 stop bit */
 #define USART_STOPBITS_0_5		USART_CR2_STOPBITS_0_5 /* .5 stop bit */
 #define USART_STOPBITS_2		USART_CR2_STOPBITS_2   /* 2 stop bits */
 #define USART_STOPBITS_1_5		USART_CR2_STOPBITS_1_5 /* 1.5 stop bit*/
+#endif
 /**@}*/
 
 /* CR3_CTSE/CR3_RTSE combined values */
@@ -128,6 +136,8 @@ void usart_enable_error_interrupt(uint32_t usart);
 void usart_disable_error_interrupt(uint32_t usart);
 bool usart_get_flag(uint32_t usart, uint32_t flag);
 bool usart_get_interrupt_source(uint32_t usart, uint32_t flag);
+
+
 
 END_DECLS
 

--- a/include/unicore-mx/stm32/common/usart_common_f124.h
+++ b/include/unicore-mx/stm32/common/usart_common_f124.h
@@ -54,7 +54,9 @@ specific memorymap.h header before including this header file.*/
 #define UART5_DR			USART_DR(UART5_BASE)
 
 /* Baud rate register (USARTx_BRR) */
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART_BRR(usart_base)		MMIO32((usart_base) + 0x08)
+#endif
 #define USART1_BRR			USART_BRR(USART1_BASE)
 #define USART2_BRR			USART_BRR(USART2_BASE)
 #define USART3_BRR			USART_BRR(USART3_BASE)
@@ -100,6 +102,7 @@ specific memorymap.h header before including this header file.*/
 
 @{*/
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 /** CTS: CTS flag */
 /** @note: undefined on UART4 and UART5 */
 #define USART_SR_CTS			(1 << 9)
@@ -131,6 +134,7 @@ specific memorymap.h header before including this header file.*/
 /** PE: Parity error */
 #define USART_SR_PE			(1 << 0)
 /**@}*/
+#endif
 
 /* --- USART_DR values ----------------------------------------------------- */
 
@@ -146,6 +150,7 @@ specific memorymap.h header before including this header file.*/
 
 /* --- USART_CR1 values ---------------------------------------------------- */
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 /* UE: USART enable */
 #define USART_CR1_UE			(1 << 13)
 
@@ -188,10 +193,14 @@ specific memorymap.h header before including this header file.*/
 /* SBK: Send break */
 #define USART_CR1_SBK			(1 << 0)
 
+#endif
+
 /* --- USART_CR2 values ---------------------------------------------------- */
 
 /* LINEN: LIN mode enable */
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART_CR2_LINEN			(1 << 14)
+#endif
 
 /* STOP[13:12]: STOP bits */
 #define USART_CR2_STOPBITS_1		(0x00 << 12)     /* 1 stop bit */
@@ -201,6 +210,7 @@ specific memorymap.h header before including this header file.*/
 #define USART_CR2_STOPBITS_MASK         (0x03 << 12)
 #define USART_CR2_STOPBITS_SHIFT        12
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 /* CLKEN: Clock enable */
 #define USART_CR2_CLKEN			(1 << 11)
 
@@ -218,12 +228,13 @@ specific memorymap.h header before including this header file.*/
 
 /* LBDL: LIN break detection length */
 #define USART_CR2_LBDL			(1 << 5)
-
+#endif
 /* ADD[3:0]: Address of the usart node */
 #define USART_CR2_ADD_MASK              0xF
 
 /* --- USART_CR3 values ---------------------------------------------------- */
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 /* CTSIE: CTS interrupt enable */
 /* Note: N/A on UART4 & UART5 */
 #define USART_CR3_CTSIE			(1 << 10)
@@ -263,6 +274,8 @@ specific memorymap.h header before including this header file.*/
 
 /* EIE: Error interrupt enable */
 #define USART_CR3_EIE			(1 << 0)
+
+#endif
 
 /* --- USART_GTPR values --------------------------------------------------- */
 

--- a/include/unicore-mx/stm32/common/usart_common_f24.h
+++ b/include/unicore-mx/stm32/common/usart_common_f24.h
@@ -36,9 +36,11 @@ specific memorymap.h header before including this header file.*/
 
 /* --- Convenience macros -------------------------------------------------- */
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 #define USART6				USART6_BASE
 #define UART7				UART7_BASE
 #define UART8				UART8_BASE
+#endif
 
 /* --- USART registers ----------------------------------------------------- */
 
@@ -79,6 +81,7 @@ specific memorymap.h header before including this header file.*/
 
 /* --- USART_CR1 values ---------------------------------------------------- */
 
+#if !(__HAL_USE) && !(__CMSIS_USE)
 /* OVER8: Oversampling mode */
 #define USART_CR1_OVER8			(1 << 15)
 
@@ -86,6 +89,8 @@ specific memorymap.h header before including this header file.*/
 
 /* ONEBIT: One sample bit method enable */
 #define USART_CR3_ONEBIT		(1 << 11)
+
+#endif  //(__HAL_USE) && !(__CMSIS_USE)
 
 #endif
 /** @cond */

--- a/include/unicore-mx/stm32/f4/memorymap.h
+++ b/include/unicore-mx/stm32/f4/memorymap.h
@@ -22,6 +22,7 @@
 
 /* --- STM32F4 specific peripheral definitions ----------------------------- */
 
+#if !(__CMSIS_USE)
 /* Memory map for all busses */
 #define PERIPH_BASE			(0x40000000U)
 #define PERIPH_BASE_APB1		(PERIPH_BASE + 0x00000)
@@ -96,6 +97,7 @@
 #define SAI1_BASE			(PERIPH_BASE_APB2 + 0x5800)
 #define LTDC_BASE			(PERIPH_BASE_APB2 + 0x6800)
 /* PERIPH_BASE_APB2 + 0x6C00 (0x4001 6C00 - 0x4001 FFFF): Reserved */
+#endif //!(__CMSIS_USE)
 
 /* AHB1 */
 #define GPIO_PORT_A_BASE		(PERIPH_BASE_AHB1 + 0x0000)
@@ -110,6 +112,7 @@
 #define GPIO_PORT_J_BASE		(PERIPH_BASE_AHB1 + 0x2400)
 #define GPIO_PORT_K_BASE		(PERIPH_BASE_AHB1 + 0x2800)
 /* PERIPH_BASE_AHB1 + 0x2C00 (0x4002 2C00 - 0x4002 2FFF): Reserved */
+#if !(__CMSIS_USE)
 #define CRC_BASE			(PERIPH_BASE_AHB1 + 0x3000)
 /* PERIPH_BASE_AHB1 + 0x3400 (0x4002 3400 - 0x4002 37FF): Reserved */
 #define RCC_BASE			(PERIPH_BASE_AHB1 + 0x3800)
@@ -140,6 +143,7 @@
 
 /* PPIB */
 #define DBGMCU_BASE			(PPBI_BASE + 0x00042000)
+#endif
 
 /* Device Electronic Signature */
 #define DESIG_FLASH_SIZE_BASE		(0x1FFF7A22U)

--- a/include/unicore-mx/stm32/f4/rcc.h
+++ b/include/unicore-mx/stm32/f4/rcc.h
@@ -44,6 +44,7 @@
 #define UNICOREMX_RCC_H
 
 /* --- RCC registers ------------------------------------------------------- */
+#include <unicore-mx/common/cmsis.h>
 
 #define RCC_CR					MMIO32(RCC_BASE + 0x00)
 #define RCC_PLLCFGR				MMIO32(RCC_BASE + 0x04)
@@ -83,23 +84,26 @@
 #define RCC_DCKCFGR				MMIO32(RCC_BASE + 0x8C)
 
 /* --- RCC_CR values ------------------------------------------------------- */
-
-#define RCC_CR_PLLSAIRDY			(1 << 29)
-#define RCC_CR_PLLSAION				(1 << 28)
-#define RCC_CR_PLLI2SRDY			(1 << 27)
-#define RCC_CR_PLLI2SON				(1 << 26)
-#define RCC_CR_PLLRDY				(1 << 25)
-#define RCC_CR_PLLON				(1 << 24)
-#define RCC_CR_CSSON				(1 << 19)
-#define RCC_CR_HSEBYP				(1 << 18)
-#define RCC_CR_HSERDY				(1 << 17)
-#define RCC_CR_HSEON				(1 << 16)
+#define RCC_CR_PLLSAIRDY    (1ul << 29)
+#define RCC_CR_PLLSAION     (1ul << 28)
+#if !(__CMSIS_USE)
+#define RCC_CR_PLLI2SRDY    (1ul << 27)
+#define RCC_CR_PLLI2SON     (1ul << 26)
+#define RCC_CR_PLLRDY       (1ul << 25)
+#define RCC_CR_PLLON        (1ul << 24)
+#define RCC_CR_CSSON        (1ul << 19)
+#define RCC_CR_HSEBYP       (1ul << 18)
+#define RCC_CR_HSERDY       (1ul << 17)
+#define RCC_CR_HSEON        (1ul << 16)
+#endif
 /* HSICAL: [15:8] */
 /* HSITRIM: [7:3] */
 #define RCC_CR_HSITRIM_SHIFT			3
 #define RCC_CR_HSITRIM_MASK			0x1f
+#if !(__CMSIS_USE)
 #define RCC_CR_HSIRDY				(1 << 1)
 #define RCC_CR_HSION				(1 << 0)
+#endif
 
 /* --- RCC_PLLCFGR values -------------------------------------------------- */
 
@@ -109,7 +113,9 @@
 /* PLLQ: [27:24] */
 #define RCC_PLLCFGR_PLLQ_SHIFT			24
 #define RCC_PLLCFGR_PLLQ_MASK			0xf
+#if !(__CMSIS_USE)
 #define RCC_PLLCFGR_PLLSRC			(1 << 22)
+#endif
 /* PLLP: [17:16] */
 #define RCC_PLLCFGR_PLLP_SHIFT			16
 #define RCC_PLLCFGR_PLLP_MASK			0x3
@@ -142,7 +148,9 @@
 #define RCC_CFGR_MCOPRE_DIV_5			0x7
 
 /* I2SSRC: I2S clock selection */
-#define RCC_CFGR_I2SSRC				(1 << 23)
+#if !(__CMSIS_USE)
+#define RCC_CFGR_I2SSRC				(1ul << 23)
+#endif
 
 /* MCO1: Microcontroller clock output 1 */
 #define RCC_CFGR_MCO1_SHIFT			21
@@ -184,17 +192,22 @@
 
 /* SWS: System clock switch status */
 #define RCC_CFGR_SWS_SHIFT			2
+#if !(__CMSIS_USE)
 #define RCC_CFGR_SWS_HSI			0x0
 #define RCC_CFGR_SWS_HSE			0x1
 #define RCC_CFGR_SWS_PLL			0x2
+#endif
 
 /* SW: System clock switch */
 #define RCC_CFGR_SW_SHIFT			0
+#if !(__CMSIS_USE)
 #define RCC_CFGR_SW_HSI				0x0
 #define RCC_CFGR_SW_HSE				0x1
 #define RCC_CFGR_SW_PLL				0x2
+#endif
 
 /* --- RCC_CIR values ------------------------------------------------------ */
+#if !(__CMSIS_USE)
 
 /* Clock security system interrupt clear bit */
 #define RCC_CIR_CSSC				(1 << 23)
@@ -535,6 +548,7 @@
 #define RCC_SSCGR_MODPER_SHIFT			0
 #define RCC_SSCGR_MODPER_MASK			0xfff
 
+#endif //!(__CMSIS_USE)
 /* --- RCC_PLLI2SCFGR values ----------------------------------------------- */
 
 /* RCC_PLLI2SCFGR[30:28]: PLLI2SR */


### PR DESCRIPTION
this branch alllows use CMSIS support, and mix code with HAL includes.

        !!! HAL library MUST be included BEFORE unicore, to avoid conflicts
        !!! prefer use GPIOx_BASE for unicore routines parameters instead of GPIOx to avoid type conflicts

only USART, RCC, OTG, GPIO are checked now