### PR TITLE
Define _bss in the linker script

### DIFF
--- a/lib/nrf/51/libucmx_nrf51.ld
+++ b/lib/nrf/51/libucmx_nrf51.ld
@@ -86,6 +86,7 @@ SECTIONS
 	_data_loadaddr = LOADADDR(.data);
 
 	.bss : {
+		_bss = .;
 		*(.bss*)	/* Read-write zero initialized data */
 		*(COMMON)
 		. = ALIGN(4);


### PR DESCRIPTION
_bss was missing in the nrf51 linker script