### PR TITLE
Weak flash wait

### DIFF
--- a/lib/stm32/common/flash_common_f01.c
+++ b/lib/stm32/common/flash_common_f01.c
@@ -142,7 +142,7 @@ This loops indefinitely until an operation (write or erase) has completed by
 testing the busy flag.
 */
 
-void flash_wait_for_last_operation(void)
+void __attribute__((weak)) flash_wait_for_last_operation(void)
 {
 	while ((flash_get_status_flags() & FLASH_SR_BSY) == FLASH_SR_BSY);
 }

--- a/lib/stm32/common/flash_common_f234.c
+++ b/lib/stm32/common/flash_common_f234.c
@@ -110,7 +110,7 @@ This loops indefinitely until an operation (write or erase) has completed by
 testing the busy flag.
 */
 
-void flash_wait_for_last_operation(void)
+void __attribute__((weak)) flash_wait_for_last_operation(void)
 {
 	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY);
 }

--- a/lib/stm32/l4/flash.c
+++ b/lib/stm32/l4/flash.c
@@ -132,7 +132,7 @@ void flash_clear_bsy_flag(void)
  * This loops indefinitely until an operation (write or erase) has completed
  * by testing the busy flag.
  */
-void flash_wait_for_last_operation(void)
+void __attribute__((weak)) flash_wait_for_last_operation(void)
 {
 	while ((FLASH_SR & FLASH_SR_BSY) == FLASH_SR_BSY);
 }


### PR DESCRIPTION
I made the definition of `flash_wait_for_last_operation()` ((weak)) to allow frosted to override this method by redefining **how** to sleep while the flash operation is in progress.